### PR TITLE
#35 - Accordion Bordered

### DIFF
--- a/lib/providers/stats_provider.dart
+++ b/lib/providers/stats_provider.dart
@@ -15,7 +15,7 @@ import 'package:covid19mobile/model/stats_model.dart';
 import 'package:flutter/material.dart';
 
 /// Creates a Provider for updating UI
-class StatsProvider with ChangeNotifier {
+class StatsProvider extends ChangeNotifier {
   String _recovered = "0";
   String get recovered => _recovered;
 

--- a/lib/resources/style/text_styles.dart
+++ b/lib/resources/style/text_styles.dart
@@ -44,6 +44,7 @@ class TextStyles {
   static TextStyle h4({Color color = Covid19Colors.darkGrey}) =>
       GoogleFonts.lato(
           textStyle: TextStyle(
+            color: color,
         fontWeight: FontWeight.w900,
         fontSize: 14.0,
       ));

--- a/lib/resources/style/themes.dart
+++ b/lib/resources/style/themes.dart
@@ -57,5 +57,6 @@ class Themes {
     primaryColor: colorPrimary,
     accentColor: colorAccent,
     textTheme: defaultTextTheme,
+    unselectedWidgetColor: colorPrimary,
   );
 }

--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -20,7 +20,7 @@ import 'package:logger/logger.dart';
 import 'package:provider/provider.dart';
 
 /// Used to log all the events happening
-Logger logger = Logger();
+final Logger logger = Logger();
 
 /// Starting class for the project
 class CovidApp extends StatelessWidget {

--- a/lib/ui/screens/home/components/accordion.dart
+++ b/lib/ui/screens/home/components/accordion.dart
@@ -1,0 +1,70 @@
+///     This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+
+class Accordion extends StatelessWidget {
+  const Accordion({
+    Key key,
+    this.title,
+    this.children,
+    this.onExpansionChanged,
+    this.initiallyExpanded = false,
+  }) : super(key: key);
+
+  final String title;
+  final bool initiallyExpanded;
+  final List<Widget> children;
+  final Function(bool) onExpansionChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(title != null, 'Title cannot be null');
+
+    return Theme(
+      data: Theme.of(context).copyWith(
+        dividerColor: Colors.transparent,
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 15.0),
+        margin: const EdgeInsets.symmetric(horizontal: 15.0),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: Theme.of(context).primaryColor,
+          ),
+          borderRadius: BorderRadius.circular(3.0),
+        ),
+        child: ListTileTheme(
+          contentPadding: EdgeInsets.zero,
+          iconColor: Theme.of(context).primaryColor,
+          child: ExpansionTile(
+            title: Text(
+              title,
+              style: Theme.of(context).textTheme.display4,
+            ),
+            initiallyExpanded: initiallyExpanded,
+            onExpansionChanged: onExpansionChanged,
+            children: children
+                ?.map(
+                  (child) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 10.0),
+                    child: child,
+                  ),
+                )
+                ?.toList(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: COVID19 App
 version: 1.0.0+3
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/test/widget/widget_test.dart
+++ b/test/widget/widget_test.dart
@@ -1,0 +1,43 @@
+///     This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:covid19mobile/ui/screens/home/components/accordion.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'widget_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('Widget: Accordion Widget', () {
+    testWidgets('has empty text title, should throw an exception', (tester) async {
+      await tester.pumpWidget(Accordion());
+      expect(tester.takeException(), isInstanceOf<AssertionError>());
+    });
+
+    testWidgets('has title and children, should render properly', (tester) async {
+      await tester.pumpWithEnvironment(Accordion(
+        title: 'Foo',
+        children: <Widget>[Text('Some child')],
+      ));
+
+      // Check collapsed (only title is showing)
+      expect(find.byType(Accordion), findsOneWidget);
+      expect(find.byType(Text), findsOneWidget);
+
+      // Check expanded (is expanded and 2 texts are rendered, both title and content)
+      await tester.tap(find.byType(ExpansionTile));
+      await tester.pumpAndSettle();
+      expect(find.byType(Text), findsNWidgets(2));
+    });
+  });
+}

--- a/test/widget/widget_test_utils.dart
+++ b/test/widget/widget_test_utils.dart
@@ -11,6 +11,11 @@
 ///    You should have received a copy of the GNU General Public License
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-void main() {
-  // Empty by design
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+extension Environment on WidgetTester {
+  Future<void> pumpWithEnvironment(Widget subjectToBeTested) async => await pumpWidget(MaterialApp(
+        home: Scaffold(body: subjectToBeTested),
+      ));
 }


### PR DESCRIPTION
Adds `Accordion` widget along with its widget test to make sure it renders properly.

Check design on #35.

Result renders as below:

### Collapsed 
![Captura de ecrã 2020-03-20, às 12 18 51](https://user-images.githubusercontent.com/27860743/77165287-e4458500-6aa9-11ea-9711-5c062f96d6f9.png)

### Expanded
![Captura de ecrã 2020-03-20, às 12 18 52](https://user-images.githubusercontent.com/27860743/77165297-e7407580-6aa9-11ea-9281-e0adb59543cd.png)

Closes #35.