### PR TITLE
Set dependency intl 0.16.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -303,7 +303,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.16.0"
   io:
     dependency: transitive
     description:
@@ -485,7 +485,7 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3"
+    version: "1.4.2"
   pubspec_parse:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_cupertino_localizations: 1.0.1
-  intl: 0.16.1
+  intl: 0.16.0
 
   # Services
   dio: 3.0.9


### PR DESCRIPTION
Closes #84 

**Description**
When using intl version 0.16.1 causes problems with the test dependency, so we should fix it at 0.16.0