### PR TITLE
Accordion (#34)

### DIFF
--- a/lib/resources/style/themes.dart
+++ b/lib/resources/style/themes.dart
@@ -55,7 +55,7 @@ class Themes {
     brightness: Brightness.light,
     fontFamily: "Lato",
     primaryColor: colorPrimary,
-    accentColor: colorAccent,
+    accentColor: colorPrimary,
     textTheme: defaultTextTheme,
     unselectedWidgetColor: colorPrimary,
   );

--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -13,6 +13,7 @@
 
 import 'package:covid19mobile/bloc/app_bloc.dart';
 import 'package:covid19mobile/generated/l10n.dart';
+import 'package:covid19mobile/resources/style/themes.dart';
 import 'package:covid19mobile/ui/screens/home/home_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -37,9 +38,7 @@ class CovidApp extends StatelessWidget {
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,
         ],
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-        ),
+        theme: Themes.defaultAppTheme,
         initialRoute: '/',
         routes: {
           '/': (_) => HomePage(title: 'Covid 19 App').builder,

--- a/lib/ui/screens/home/components/accordion.dart
+++ b/lib/ui/screens/home/components/accordion.dart
@@ -19,13 +19,16 @@ class Accordion extends StatelessWidget {
     this.title,
     this.children,
     this.onExpansionChanged,
+    this.withBorder = true,
     this.initiallyExpanded = false,
   }) : super(key: key);
 
   final String title;
-  final bool initiallyExpanded;
   final List<Widget> children;
   final Function(bool) onExpansionChanged;
+
+  final bool initiallyExpanded;
+  final bool withBorder;
 
   @override
   Widget build(BuildContext context) {
@@ -38,15 +41,16 @@ class Accordion extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 15.0),
         margin: const EdgeInsets.symmetric(horizontal: 15.0),
-        decoration: BoxDecoration(
-          border: Border.all(
-            color: Theme.of(context).primaryColor,
-          ),
-          borderRadius: BorderRadius.circular(3.0),
-        ),
+        decoration: withBorder
+            ? BoxDecoration(
+                border: Border.all(
+                  color: Theme.of(context).primaryColor,
+                ),
+                borderRadius: BorderRadius.circular(3.0),
+              )
+            : null,
         child: ListTileTheme(
           contentPadding: EdgeInsets.zero,
-          iconColor: Theme.of(context).primaryColor,
           child: ExpansionTile(
             title: Text(
               title,
@@ -58,7 +62,10 @@ class Accordion extends StatelessWidget {
                 ?.map(
                   (child) => Padding(
                     padding: const EdgeInsets.symmetric(vertical: 10.0),
-                    child: child,
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: child,
+                    ),
                   ),
                 )
                 ?.toList(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   flutter_cupertino_localizations: 1.0.1
-  intl: 0.16.1
+  intl: 0.16.0
 
   # Services
   dio: 3.0.9

--- a/test/widget/widget_test.dart
+++ b/test/widget/widget_test.dart
@@ -19,16 +19,32 @@ import 'widget_test_utils.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   group('Widget: Accordion Widget', () {
-    testWidgets('has empty text title, should throw an exception',
-        (tester) async {
+    testWidgets('has empty text title, should throw an exception', (tester) async {
       await tester.pumpWidget(Accordion());
       expect(tester.takeException(), isInstanceOf<AssertionError>());
     });
 
-    testWidgets('has title and children, should render properly',
-        (tester) async {
+    testWidgets('has title and children, should render properly with a border', (tester) async {
       await tester.pumpWithEnvironment(Accordion(
         title: 'Foo',
+        children: <Widget>[Text('Some child')],
+      ));
+
+      // Check collapsed (only title is showing) and has border
+      expect(find.byType(Accordion), findsOneWidget);
+      expect(find.byType(Text), findsOneWidget);
+      expect(find.byType(DecoratedBox), findsWidgets);
+
+      // Check expanded (is expanded and 2 texts are rendered, both title and content)
+      await tester.tap(find.byType(ExpansionTile));
+      await tester.pumpAndSettle();
+      expect(find.byType(Text), findsNWidgets(2));
+    });
+
+    testWidgets('has title and children, should render without a border', (tester) async {
+      await tester.pumpWithEnvironment(Accordion(
+        title: 'Foo',
+        withBorder: false,
         children: <Widget>[Text('Some child')],
       ));
 
@@ -40,6 +56,9 @@ void main() {
       await tester.tap(find.byType(ExpansionTile));
       await tester.pumpAndSettle();
       expect(find.byType(Text), findsNWidgets(2));
+
+      // Check if no decoration is being applied (border)
+      expect(find.byType(BoxDecoration), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Adds `withBorder` property to `Accordion` (which defaults to `true`) that lets either use a bordered Accordion (see #35) or not.

Includes updated widget test.

Check design on #34.

Result is as below:
### Collapsed
![Captura de ecrã 2020-03-21, às 11 10 33](https://user-images.githubusercontent.com/27860743/77225642-aeb3a100-6b68-11ea-93de-3ba867ccb39a.png)

### Expanded
![Captura de ecrã 2020-03-21, às 11 10 27](https://user-images.githubusercontent.com/27860743/77225641-ae1b0a80-6b68-11ea-8150-69097c6638cc.png)

Closes #34.
