### PR TITLE
Card Video (#26)

### DIFF
--- a/lib/ui/screens/home/components/card_video.dart
+++ b/lib/ui/screens/home/components/card_video.dart
@@ -1,0 +1,83 @@
+import 'package:covid19mobile/resources/style/text_styles.dart';
+import 'package:flutter/material.dart';
+
+///     This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+class CardVideo extends StatelessWidget {
+  const CardVideo({
+    Key key,
+    @required this.backgroundUrl,
+    this.onPressed,
+    this.label,
+    this.labelAlignment = Alignment.bottomCenter,
+  }) : super(key: key);
+
+  final String backgroundUrl;
+  final String label;
+  final Alignment labelAlignment;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 100.0,
+      margin: const EdgeInsets.all(5.0),
+      padding: const EdgeInsets.all(5.0),
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(4.0),
+        image: DecorationImage(
+          image: NetworkImage(backgroundUrl),
+          fit: BoxFit.cover,
+        ),
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: <Widget>[
+          ButtonTheme(
+            minWidth: 0.0,
+            shape: const CircleBorder(),
+            padding: EdgeInsets.zero,
+            buttonColor: Colors.transparent,
+            splashColor: Colors.transparent,
+            highlightColor: Colors.transparent,
+            child: RaisedButton(
+              elevation: 4.0,
+              onPressed: () {},
+              disabledColor: Colors.transparent,
+              child: Icon(
+                Icons.play_circle_filled,
+                size: 48.0,
+                color: onPressed == null ? Theme.of(context).textTheme.button.color : Theme.of(context).disabledColor,
+              ),
+            ),
+          ),
+          if (label != null)
+            Align(
+              alignment: labelAlignment,
+              child: Text(
+                label,
+                style: TextStyles.subtitle(color: Colors.white).copyWith(shadows: [
+                  const Shadow(
+                    offset: Offset(0.0, 1.0),
+                    blurRadius: 3.0,
+                  ),
+                ]),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Adds `CardVideo` that takes background URL (image) as required parameter and, optionally, a label which can be positioned using the `labelAlignment` property (defaults to `Alignment.bottomCenter`).

Based on design, the label can have multiple locations, see [here](https://app.zeplin.io/project/5e711e6973c497b6352ed9f3/screen/5e73b66e1285030494b00dee) and [here](https://zpl.io/a38lzR1), thus, the `labelAlignment` property.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27860743/77226988-44a0f900-6b74-11ea-89ba-9e6a9b6f8601.gif)

Closed #26.

