### PR TITLE
faqs page improvents on collapse and expand, adds widget homecard tests

### DIFF
--- a/lib/ui/screens/contacts/components/contact_card.dart
+++ b/lib/ui/screens/contacts/components/contact_card.dart
@@ -35,16 +35,19 @@ class ContactCard extends StatelessWidget {
     return Theme(
       data: Theme.of(context).copyWith(
         dividerColor: Colors.transparent,
+        splashColor: Covid19Colors.green,
       ),
       child: SingleChildScrollView(
-        child: Container(
-          color: Covid19Colors.contactCardBackgroundGrey,
-          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-          margin: const EdgeInsets.symmetric(vertical: 4.0),
-          child: ListTileTheme(
-            contentPadding: EdgeInsets.zero,
+        child: ListTileTheme(
+          contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Card(
+            margin: const EdgeInsets.symmetric(vertical: 4.0),
+            color: Covid19Colors.contactCardBackgroundGrey,
+            elevation: 0.0,
             child: ListTile(
-              contentPadding: EdgeInsets.only(top: 8, bottom: 8),
+              contentPadding: EdgeInsets.only(
+                  left: 12, right: 12,
+                  top: 12, bottom: 12),
               onTap: () => onTap(contact),
               title: Text(
                 contact.title,

--- a/lib/ui/screens/contacts/contacts_page.dart
+++ b/lib/ui/screens/contacts/contacts_page.dart
@@ -111,16 +111,18 @@ class _ContactsPageState extends State<ContactsPage> {
   }
 
   _onContactTap(ContactModel contact) {
-
-    print(contact.title);
-
     switch(contact.contactType) {
-
       case ContactType.phone:
         _launch("tel: ${contact.title}");
         break;
       case ContactType.link:
-        _launch(contact.title);
+
+        var urlToOpen = contact.title;
+        if(!(contact.title.startsWith("https://") || contact.title.startsWith("http://"))) {
+          urlToOpen = "https://${contact.title}";
+        }
+
+        _launch(urlToOpen);
         break;
       case ContactType.email:
         _launch("mailto: ${contact.title}");

--- a/lib/ui/screens/home/components/card_home.dart
+++ b/lib/ui/screens/home/components/card_home.dart
@@ -1,6 +1,3 @@
-import 'package:covid19mobile/ui/assets/colors.dart';
-import 'package:covid19mobile/ui/widgets/button_background.dart';
-
 ///    This program is free software: you can redistribute it and/or modify
 ///    it under the terms of the GNU General Public License as published by
 ///    the Free Software Foundation, either version 3 of the License, or
@@ -15,46 +12,62 @@ import 'package:covid19mobile/ui/widgets/button_background.dart';
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:flutter/material.dart';
+import 'package:covid19mobile/ui/assets/colors.dart';
 
 class CardHome extends StatelessWidget {
   final String text;
   final VoidCallback callback;
   final Color backgroundColor;
   final Color textColor;
+  final Color borderColor;
 
   const CardHome({
     Key key,
     @required this.text,
     @required this.callback,
+    Color borderColor,
     Color backgroundColor,
     Color textColor,
   }) :
         backgroundColor = backgroundColor ?? Covid19Colors.lightGrey,
         textColor = textColor ?? Covid19Colors.darkGrey,
+        borderColor = borderColor ?? Colors.transparent,
         super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: callback,
-      child: ButtonBackground(
-        color: backgroundColor,
-        child: Row(
-          children: <Widget>[
-            Expanded(
-              child: Text(
-                text.toUpperCase(),
-                style: Theme.of(context)
-                    .textTheme
-                    .display2
-                    .copyWith(color: textColor),
-              ),
+
+    return Theme(
+      data: Theme.of(context).copyWith(
+        dividerColor: Colors.transparent,
+        splashColor: backgroundColor == Covid19Colors.green ? Covid19Colors.grey : Covid19Colors.green,
+      ),
+      child: ListTileTheme(
+        contentPadding: EdgeInsets.symmetric(horizontal: 15),
+        child: Card(
+          color: backgroundColor,
+          shape: borderColor != Colors.transparent ? ContinuousRectangleBorder(
+            side: BorderSide(
+              color: borderColor,
+              width: 2.0,
             ),
-            Icon(
+            borderRadius: BorderRadius.circular(4.0),
+          ) : null,
+          elevation: 0.0,
+          child: ListTile(
+            onTap: callback,
+            title: Text(
+              text.toUpperCase(),
+              style: Theme.of(context)
+                  .textTheme
+                  .display2
+                  .copyWith(color: textColor),
+            ),
+            trailing: Icon(
               Icons.arrow_forward,
               color: textColor,
-            )
-          ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/home/home_page.dart
+++ b/lib/ui/screens/home/home_page.dart
@@ -121,9 +121,10 @@ class _HomePageState extends BaseState<HomePage, AppBloc> {
                   const SizedBox(
                     height: 8,
                   ),
-                  CardBorderArrow(
+                  CardHome(
                     text: S.of(context).screenAboutTitle.toUpperCase(),
                     callback: () => Navigator.of(context).pushNamed(routeAbout),
+                    backgroundColor: Colors.transparent,
                     textColor: Covid19Colors.darkGrey,
                     borderColor: Covid19Colors.lightGrey,
                   ),

--- a/test/widget/card_home_widget_test.dart
+++ b/test/widget/card_home_widget_test.dart
@@ -1,0 +1,84 @@
+///     This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:covid19mobile/ui/assets/colors.dart';
+import 'package:covid19mobile/ui/screens/home/components/card_home.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'widget_test_utils.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  group('Widget: Card Home Widget', () {
+
+    testWidgets('Card Home with background', (tester) async {
+
+          await tester.pumpWithEnvironment(
+              CardHome(
+                text: "text",
+                callback: () => {},
+                backgroundColor: Covid19Colors.green,
+                textColor: Covid19Colors.white,
+              )
+          );
+
+          // Check normal with no border
+          expect(find.byType(CardHome), findsOneWidget);
+          expect(find.byType(Text), findsOneWidget);
+          expect(find.byType(ContinuousRectangleBorder), findsNothing);
+
+          final CardHome cardHome = tester.firstWidget(find.byType(CardHome));
+          expect(cardHome.borderColor, Colors.transparent);
+          expect(cardHome.backgroundColor, Covid19Colors.green);
+          expect(cardHome.textColor, Covid19Colors.white);
+          expect(cardHome.text, "text");
+
+    });
+
+    testWidgets('Card Home with no background with border', (tester) async {
+
+      await tester.pumpWithEnvironment(
+          CardHome(
+            text: "text",
+            callback: () => {},
+            backgroundColor: Colors.transparent,
+            textColor: Covid19Colors.darkGrey,
+            borderColor: Covid19Colors.lightGrey,
+          )
+      );
+
+      // Check normal with no border
+      expect(find.byType(CardHome), findsOneWidget);
+      expect(find.byType(Text), findsOneWidget);
+
+      // Finds Card widget
+      Card actualBox = tester.firstWidget(find.byType(Card));
+
+      // Finds ContinuousRectangleBorder
+      ContinuousRectangleBorder shapeBorder = actualBox.shape as ContinuousRectangleBorder;
+      expect(shapeBorder.side.color, Covid19Colors.lightGrey);
+      expect(shapeBorder.side.width, 2.0);
+
+      expect(shapeBorder.borderRadius, BorderRadius.circular(4.0));
+
+      final CardHome cardHome = tester.firstWidget(find.byType(CardHome));
+      expect(cardHome.borderColor, Covid19Colors.lightGrey);
+      expect(cardHome.backgroundColor, Colors.transparent);
+      expect(cardHome.textColor, Covid19Colors.darkGrey);
+      expect(cardHome.text, "text");
+
+    });
+  });
+}


### PR DESCRIPTION
closes #111 

Home Page CarHome -> 
- widget converted into a ListTile to use the theme
- add 2 more widget tests

Faqs page
- adds Scrolbar
- on expand collapse others that are expanded

Contacts Page
- the link was fixed, was not opening the web
- adds tap effect - same from Homecard

✅ All tests passed