### PR TITLE
#142 - Add background when video thumbnail is null

### DIFF
--- a/lib/ui/widgets/card_video.dart
+++ b/lib/ui/widgets/card_video.dart
@@ -30,6 +30,19 @@ class CardVideo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final decoration = backgroundUrl == null
+        ? BoxDecoration(
+            borderRadius: BorderRadius.circular(4.0),
+            color: Theme.of(context).primaryColor,
+          )
+        : BoxDecoration(
+            borderRadius: BorderRadius.circular(4.0),
+            image: DecorationImage(
+              image: NetworkImage(backgroundUrl),
+              fit: BoxFit.cover,
+            ),
+          );
+
     return GestureDetector(
       onTap: onPressed,
       child: Container(
@@ -37,13 +50,7 @@ class CardVideo extends StatelessWidget {
         margin: const EdgeInsets.all(5.0),
         padding: const EdgeInsets.all(18.0),
         alignment: Alignment.center,
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(4.0),
-          image: DecorationImage(
-            image: NetworkImage(backgroundUrl),
-            fit: BoxFit.cover,
-          ),
-        ),
+        decoration: decoration,
         child: Stack(
           alignment: Alignment.center,
           children: <Widget>[


### PR DESCRIPTION
closes #142 

**Description** 
* Adds green background when thumbnail is null
* Green background approved by VOST

**Screenshot**
![WhatsApp Image 2020-03-23 at 10 50 51(1)](https://user-images.githubusercontent.com/10728633/77310569-72ae4680-6cf6-11ea-936e-e9ecd9f8ec34.jpeg)
