### PR TITLE
UI Fix - Navigation Transitions (#148)

### DIFF
--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -35,6 +35,7 @@ import 'package:covid19mobile/ui/screens/statistics/statistics_page.dart';
 import 'package:covid19mobile/ui/screens/video_player/video_player_page.dart';
 import 'package:covid19mobile/ui/screens/videos/videos_page.dart';
 import 'package:covid19mobile/ui/screens/measures/measures_page.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:logger/logger.dart';
@@ -77,23 +78,24 @@ class CovidApp extends StatelessWidget {
         ],
         theme: Themes.defaultAppTheme,
         initialRoute: '/',
-        routes: {
-          '/': (_) => HomePage(title: 'Covid 19 App'),
-          routeStatistics: (_) => StatisticsPage(),
-          routeContacts: (_) => ContactsPage(),
-          routeRemoteWork: (context) =>
-              RemoteWorkPage(title: S.of(context).screenRemoteWorkTitle),
-          routeRemoteWorkDetails: (context) => RemoteWorkDetails(),
-          routeFaqs: (_) => FaqsPage(title: 'Perguntas Frequentes'),
-          routeVideos: (_) => VideosPage(title: 'Vídeos'),
-          routeAbout: (_) => AboutPage(),
-          routeVideoPlayer: (_) => VideoPlayerPage(),
-          routeInitiatives: (context) =>
-              InitiativesPage(title: S.of(context).initiativesPageTitle),
-          routeNotifications: (_) => NotificationsPage(),
-          routeMeasures: (_) =>
-              MeasuresPage(title: 'Medidas Excecionais'),
-          routeLicences: (_) => LicensePage()
+        onGenerateRoute: (settings) {
+          final Map<String, Widget> routes = {
+            '/': HomePage(title: 'Covid 19 App'),
+            routeStatistics: StatisticsPage(),
+            routeContacts: ContactsPage(),
+            routeRemoteWork: RemoteWorkPage(),
+            routeRemoteWorkDetails: RemoteWorkDetails(),
+            routeFaqs: FaqsPage(title: 'Perguntas Frequentes'),
+            routeVideos: VideosPage(title: 'Vídeos'),
+            routeAbout: AboutPage(),
+            routeVideoPlayer: VideoPlayerPage(),
+            routeInitiatives: InitiativesPage(),
+            routeNotifications: NotificationsPage(),
+            routeMeasures: MeasuresPage(title: 'Medidas Excecionais'),
+            routeLicences: LicensePage()
+          };
+          return CupertinoPageRoute(
+              builder: (_) => routes[settings.name], settings: settings);
         },
       ),
     );

--- a/lib/ui/screens/home/home_page.dart
+++ b/lib/ui/screens/home/home_page.dart
@@ -12,8 +12,8 @@
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import 'package:covid19mobile/generated/l10n.dart';
 import 'package:covid19mobile/providers/faq_provider.dart';
-import 'package:covid19mobile/providers/measure_provider.dart';
 import 'package:covid19mobile/providers/initiatives_provider.dart';
+import 'package:covid19mobile/providers/measure_provider.dart';
 import 'package:covid19mobile/providers/remote_work_provider.dart';
 import 'package:covid19mobile/providers/stats_provider.dart';
 import 'package:covid19mobile/providers/videos_provider.dart';
@@ -23,10 +23,7 @@ import 'package:covid19mobile/ui/assets/colors.dart';
 import 'package:covid19mobile/ui/assets/images.dart';
 import 'package:covid19mobile/ui/core/base_stream_service_screen_page.dart';
 import 'package:covid19mobile/ui/screens/home/components/card_home.dart';
-import 'package:covid19mobile/ui/core/base_stream_service_screen_page.dart';
 import 'package:covid19mobile/ui/widgets/card_border_arrow.dart';
-import 'package:covid19mobile/generated/l10n.dart';
-
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/ui/screens/initiatives/initiatives_page.dart
+++ b/lib/ui/screens/initiatives/initiatives_page.dart
@@ -13,12 +13,12 @@
 
 import 'package:covid19mobile/bloc/app_bloc.dart';
 import 'package:covid19mobile/bloc/base_bloc.dart';
+import 'package:covid19mobile/generated/l10n.dart';
 import 'package:covid19mobile/model/initiative_model.dart';
 import 'package:covid19mobile/providers/initiatives_provider.dart';
 import 'package:covid19mobile/resources/style/text_styles.dart';
 import 'package:covid19mobile/ui/assets/colors.dart';
 import 'package:covid19mobile/ui/core/base_stream_service_screen_page.dart';
-import 'package:covid19mobile/ui/screens/home/components/accordion.dart';
 import 'package:covid19mobile/ui/widgets/initiatives_item.dart';
 import 'package:covid19mobile/ui/widgets/separator.dart';
 import 'package:flutter/material.dart';
@@ -26,10 +26,7 @@ import 'package:provider/provider.dart';
 
 class InitiativesPage extends BasePage {
   /// Initiatives page view
-  InitiativesPage({Key key, this.title}) : super(key: key);
-
-  /// Title of the page view
-  final String title;
+  InitiativesPage({Key key}) : super(key: key);
 
   @override
   _InitiativesPageState createState() => _InitiativesPageState();
@@ -86,7 +83,7 @@ class _InitiativesPageState extends BaseState<InitiativesPage, AppBloc> {
         iconTheme:
             Theme.of(context).iconTheme.copyWith(color: Covid19Colors.darkGrey),
         title: Text(
-          widget.title.toUpperCase(),
+          S.of(context).initiativesPageTitle.toUpperCase(),
           style: TextStyles.h2(color: Covid19Colors.darkGreyLight),
         ),
         backgroundColor: Colors.white,

--- a/lib/ui/screens/measures/measures_extensions.dart
+++ b/lib/ui/screens/measures/measures_extensions.dart
@@ -1,3 +1,5 @@
+import 'package:covid19mobile/extensions/date_extensions.dart';
+
 ///    This program is free software: you can redistribute it and/or modify
 ///    it under the terms of the GNU General Public License as published by
 ///    the Free Software Foundation, either version 3 of the License, or
@@ -12,14 +14,11 @@
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'package:covid19mobile/model/measure_model.dart';
-import 'package:covid19mobile/ui/assets/colors.dart';
 import 'package:covid19mobile/utils/launch_url.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:html/dom.dart' as dom;
 import 'package:html/parser.dart' show parse;
 import 'package:intl/intl.dart';
-import 'package:covid19mobile/extensions/date_extensions.dart';
 // import 'package:html/dom.dart' as dom;
 
 /// Extension class to help parse information of [MeasureModel]
@@ -52,10 +51,10 @@ extension HtmlParsing on MeasureModel {
       return Html(
         data: postContent,
         onLinkTap: launchURL,
-            linkStyle: Theme.of(context)
-                .textTheme
-                .body1
-                .copyWith(color: Theme.of(context).primaryColor),
+        linkStyle: Theme.of(context)
+            .textTheme
+            .body1
+            .copyWith(color: Theme.of(context).primaryColor),
       );
     } else {
       return null;

--- a/lib/ui/screens/remote_work/remote_work_page.dart
+++ b/lib/ui/screens/remote_work/remote_work_page.dart
@@ -13,6 +13,7 @@
 
 import 'package:covid19mobile/bloc/app_bloc.dart';
 import 'package:covid19mobile/bloc/base_bloc.dart';
+import 'package:covid19mobile/generated/l10n.dart';
 import 'package:covid19mobile/model/remote_work_model.dart';
 import 'package:covid19mobile/providers/remote_work_provider.dart';
 import 'package:covid19mobile/resources/constants.dart';
@@ -25,10 +26,7 @@ import 'package:provider/provider.dart';
 
 class RemoteWorkPage extends BasePage {
   /// Faqs page view
-  RemoteWorkPage({Key key, this.title}) : super(key: key);
-
-  /// Title of the page view
-  final String title;
+  RemoteWorkPage({Key key}) : super(key: key);
 
   @override
   _RemoteWorkState createState() => _RemoteWorkState();
@@ -53,7 +51,7 @@ class _RemoteWorkState extends BaseState<RemoteWorkPage, AppBloc> {
         iconTheme:
             Theme.of(context).iconTheme.copyWith(color: Covid19Colors.darkGrey),
         title: Text(
-          widget.title.toUpperCase(),
+          S.of(context).screenRemoteWorkTitle.toUpperCase(),
           style: TextStyles.h2(color: Covid19Colors.darkGreyLight),
         ),
       ),

--- a/lib/ui/widgets/button_background.dart
+++ b/lib/ui/widgets/button_background.dart
@@ -1,5 +1,3 @@
-import 'package:covid19mobile/ui/assets/colors.dart';
-
 ///    This program is free software: you can redistribute it and/or modify
 ///    it under the terms of the GNU General Public License as published by
 ///    the Free Software Foundation, either version 3 of the License, or

--- a/test/unit/api_test.dart
+++ b/test/unit/api_test.dart
@@ -18,7 +18,6 @@ import 'package:covid19mobile/model/faq_model.dart';
 import 'package:covid19mobile/model/measure_model.dart';
 import 'package:covid19mobile/model/post_type.dart';
 import 'package:covid19mobile/model/remote_work_model.dart';
-import 'package:covid19mobile/model/measure_model.dart';
 import 'package:covid19mobile/model/stats_model.dart';
 import 'package:covid19mobile/model/video_model.dart';
 import 'package:covid19mobile/services/api_service.dart';


### PR DESCRIPTION
- Replaces namedRoutes with onGenerateRoute to provide a CupertinoPageRoute regardless of running platform;
- Removes unused or duplicate imports;

Closes #148.