### PR TITLE
Add API Categories FAQ

### DIFF
--- a/lib/bloc/app_bloc.dart
+++ b/lib/bloc/app_bloc.dart
@@ -14,6 +14,7 @@
 import 'dart:async';
 
 import 'package:covid19mobile/model/api_response_model.dart';
+import 'package:covid19mobile/model/faq_category_model.dart';
 import 'package:covid19mobile/model/faq_model.dart';
 import 'package:covid19mobile/model/measure_model.dart';
 import 'package:covid19mobile/model/initiative_model.dart';
@@ -109,6 +110,19 @@ class AppBloc implements Bloc {
     );
   }
 
+  void getFaqCategories() async {
+    final postType = PostType(PostTypes.faqCategories);
+
+    var results = await getPosts<FaqCategoryModel>(postType,
+        cacheKey: "FaqCategoryModel");
+
+    onStream.sink.add(
+      FaqCategoryResultStream(
+          model: results,
+          state: results != null ? StateStream.success : StateStream.fail),
+    );
+  }
+
   void getInitiatives() async {
     final postType = PostType(PostTypes.initiatives);
 
@@ -150,6 +164,16 @@ class AppBloc implements Bloc {
   /// Then returns the parsed data
   parseData<T>(PostType postType, dynamic data) {
     switch (postType.postTypes) {
+      case PostTypes.faqCategories:
+
+        /// Data converted to a Map now we need to convert each entry
+        return data.map<T>((json) =>
+
+            /// into a [FaqCategoryModel] instance and save into a List
+            FaqCategoryModel.fromJson(json)).toList();
+
+        break;
+
       case PostTypes.measures:
 
         /// Data converted to a Map now we need to convert each entry
@@ -173,7 +197,7 @@ class AppBloc implements Bloc {
         /// Data converted to a Map now we need to convert each entry
         return data.map<T>((json) =>
 
-            /// into a [RemoteWorkModel] instance and save into a List
+            /// into a [FaqModel] instance and save into a List
             FaqModel.fromJson(json)).toList();
 
         break;

--- a/lib/bloc/base_bloc.dart
+++ b/lib/bloc/base_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:covid19mobile/model/faq_category_model.dart';
 import 'package:covid19mobile/model/initiative_model.dart';
 import 'package:covid19mobile/model/video_model.dart';
 
@@ -139,4 +140,16 @@ class InitiativeResultStream
 
   /// and [model] a [Lst<InitiativeModel>] instance list
   InitiativeResultStream({this.state, this.model});
+}
+
+class FaqCategoryResultStream
+    extends ResultStream<StateStream, List<FaqCategoryModel>> {
+  @override
+  List<FaqCategoryModel> model;
+
+  @override
+  StateStream state;
+
+  /// and [model] a [Lst<FaqCategoryModel>] instance list
+  FaqCategoryResultStream({this.state, this.model});
 }

--- a/lib/model/faq_category_model.dart
+++ b/lib/model/faq_category_model.dart
@@ -1,0 +1,89 @@
+///    This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import 'package:json_annotation/json_annotation.dart';
+
+import 'base_post_model.dart';
+
+part 'faq_category_model.g.dart';
+
+@JsonSerializable(includeIfNull: false)
+class FaqCategoryModel extends BasePostModel {
+  /// FAQ Title
+  @JsonKey(name: 'name')
+  final String name;
+
+  /// FAQ Category ID
+  @JsonKey(name: 'category_id')
+  final int categoryId;
+
+  /// Constructor
+  ///
+  /// All Fields are mandatory
+  ///
+  FaqCategoryModel(
+    int id,
+    this.name,
+    this.categoryId,
+    String author,
+    String date,
+    String postDateGmt,
+    String postExcerpt,
+    String postStatus,
+    String commentStatus,
+    String pingStatus,
+    String postPassword,
+    String postName,
+    String toPing,
+    String pinged,
+    String postModified,
+    String postModifiedGMT,
+    String postContentFiltered,
+    int postParent,
+    String guid,
+    int menuOrder,
+    String postType,
+    String postMimeType,
+    String commentCount,
+    String filter,
+  ) : super(
+          id: id,
+          author: author,
+          date: date,
+          postDateGmt: postDateGmt,
+          postExcerpt: postExcerpt,
+          postStatus: postStatus,
+          commentStatus: commentStatus,
+          pingStatus: pingStatus,
+          postPassword: postPassword,
+          postName: postName,
+          toPing: toPing,
+          pinged: pinged,
+          postModified: postModified,
+          postModifiedGMT: postModifiedGMT,
+          postContentFiltered: postContentFiltered,
+          postParent: postParent,
+          guid: guid,
+          menuOrder: menuOrder,
+          postType: postType,
+          postMimeType: postMimeType,
+          commentCount: commentCount,
+          filter: filter,
+        );
+
+  /// Mapper from Json to Model
+  factory FaqCategoryModel.fromJson(Map<String, dynamic> json) =>
+      _$FaqCategoryModelFromJson(json);
+
+  /// Maps Model to Json
+  Map<String, dynamic> toJson() => _$FaqCategoryModelToJson(this);
+}

--- a/lib/model/faq_category_model.g.dart
+++ b/lib/model/faq_category_model.g.dart
@@ -1,0 +1,72 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'faq_category_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+FaqCategoryModel _$FaqCategoryModelFromJson(Map<String, dynamic> json) {
+  return FaqCategoryModel(
+    json['ID'] as int,
+    json['name'] as String,
+    json['category_id'] as int,
+    json['post_author'] as String,
+    json['post_date'] as String,
+    json['post_date_gmt'] as String,
+    json['post_excerpt'] as String,
+    json['post_status'] as String,
+    json['comment_status'] as String,
+    json['ping_status'] as String,
+    json['post_password'] as String,
+    json['post_name'] as String,
+    json['to_ping'] as String,
+    json['pinged'] as String,
+    json['post_modified'] as String,
+    json['post_modified_gmt'] as String,
+    json['post_content_filtered'] as String,
+    json['post_parent'] as int,
+    json['guid'] as String,
+    json['menu_order'] as int,
+    json['post_type'] as String,
+    json['post_mime_type'] as String,
+    json['comment_count'] as String,
+    json['filter'] as String,
+  );
+}
+
+Map<String, dynamic> _$FaqCategoryModelToJson(FaqCategoryModel instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('ID', instance.id);
+  writeNotNull('post_author', instance.author);
+  writeNotNull('post_date', instance.date);
+  writeNotNull('post_date_gmt', instance.postDateGmt);
+  writeNotNull('post_excerpt', instance.postExcerpt);
+  writeNotNull('post_status', instance.postStatus);
+  writeNotNull('comment_status', instance.commentStatus);
+  writeNotNull('ping_status', instance.pingStatus);
+  writeNotNull('post_password', instance.postPassword);
+  writeNotNull('post_name', instance.postName);
+  writeNotNull('to_ping', instance.toPing);
+  writeNotNull('pinged', instance.pinged);
+  writeNotNull('post_modified', instance.postModified);
+  writeNotNull('post_modified_gmt', instance.postModifiedGMT);
+  writeNotNull('post_content_filtered', instance.postContentFiltered);
+  writeNotNull('post_parent', instance.postParent);
+  writeNotNull('guid', instance.guid);
+  writeNotNull('menu_order', instance.menuOrder);
+  writeNotNull('post_type', instance.postType);
+  writeNotNull('post_mime_type', instance.postMimeType);
+  writeNotNull('comment_count', instance.commentCount);
+  writeNotNull('filter', instance.filter);
+  writeNotNull('name', instance.name);
+  writeNotNull('category_id', instance.categoryId);
+  return val;
+}

--- a/lib/model/post_type.dart
+++ b/lib/model/post_type.dart
@@ -12,7 +12,7 @@
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 /// Post types
-enum PostTypes { measures, remoteWork, videos, faq, initiatives }
+enum PostTypes { measures, remoteWork, videos, faq, initiatives, faqCategories }
 
 class PostType {
   final PostTypes postTypes;
@@ -21,6 +21,8 @@ class PostType {
 
   String getRequestType() {
     switch (postTypes) {
+      case PostTypes.faqCategories:
+        return '/appfaqs';
       case PostTypes.measures:
         return '/measures';
       case PostTypes.remoteWork:

--- a/lib/providers/faq_category_provider.dart
+++ b/lib/providers/faq_category_provider.dart
@@ -1,0 +1,26 @@
+///    This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/material.dart';
+import 'package:covid19mobile/model/faq_category_model.dart';
+
+class FaqCategoryProvider extends ChangeNotifier {
+  List<FaqCategoryModel> _faqs;
+
+  List<FaqCategoryModel> get faqs => _faqs;
+
+  void setFaqsCategories(List<FaqCategoryModel> values) {
+    _faqs = values;
+    notifyListeners();
+  }
+}

--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -13,6 +13,7 @@
 
 import 'package:covid19mobile/bloc/app_bloc.dart';
 import 'package:covid19mobile/generated/l10n.dart';
+import 'package:covid19mobile/providers/faq_category_provider.dart';
 import 'package:covid19mobile/providers/faq_provider.dart';
 import 'package:covid19mobile/providers/measure_provider.dart';
 import 'package:covid19mobile/providers/notifications_provider.dart';
@@ -66,6 +67,9 @@ class CovidApp extends StatelessWidget {
         ),
         ChangeNotifierProvider<MeasuresProvider>.value(
           value: MeasuresProvider(),
+        ),
+        ChangeNotifierProvider<FaqCategoryProvider>.value(
+          value: FaqCategoryProvider(),
         ),
       ],
       child: MaterialApp(

--- a/lib/ui/screens/home/home_page.dart
+++ b/lib/ui/screens/home/home_page.dart
@@ -11,6 +11,7 @@
 ///    You should have received a copy of the GNU General Public License
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import 'package:covid19mobile/generated/l10n.dart';
+import 'package:covid19mobile/providers/faq_category_provider.dart';
 import 'package:covid19mobile/providers/faq_provider.dart';
 import 'package:covid19mobile/providers/initiatives_provider.dart';
 import 'package:covid19mobile/providers/measure_provider.dart';
@@ -196,6 +197,10 @@ class _HomePageState extends BaseState<HomePage, AppBloc> {
     /// Get Initiatives Posts
     ///
     bloc.getInitiatives();
+
+    /// GET FAQS categories
+    ///
+    bloc.getFaqCategories();
   }
 
   @override
@@ -229,6 +234,11 @@ class _HomePageState extends BaseState<HomePage, AppBloc> {
     if (result is InitiativeResultStream) {
       Provider.of<InitiativesProvider>(context, listen: false)
           .setInitiatives(result.model);
+    }
+
+    if (result is FaqCategoryResultStream) {
+      Provider.of<FaqCategoryProvider>(context, listen: false)
+          .setFaqsCategories(result.model);
     }
   }
 }


### PR DESCRIPTION
Closes #166 

**Description**
Adds an endpoint point that grabs all existing FAQ categories to then grab the `category_id` and use to get the list of FAQs for that categories. 
IT is now necessary to create a screen of FAQ Categories that this endpoint will populate

**Note**
At the moment of creation of this PR, there is no Categories in DEV only in PRD.

**Changes**
✅ Add FaqCategoryModel
✅Add Providers & Bloc to homepae
✅Flutter format @ root
😞No tests added