### PR TITLE
Removes padding from the background in the stats screen

### DIFF
--- a/lib/ui/screens/statistics/components/stats_widget.dart
+++ b/lib/ui/screens/statistics/components/stats_widget.dart
@@ -35,17 +35,20 @@ class StatsWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ButtonBackground(
+      border: 0.0,
       color: color,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          StatisticsBorder(
-            color: Covid19Colors.darkGrey,
-            text: Text(
-              number,
-              style: numberStyle,
-              textAlign: TextAlign.center,
+          Center(
+            child: StatisticsBorder(
+              color: Covid19Colors.darkGrey,
+              text: Text(
+                number,
+                style: numberStyle,
+                textAlign: TextAlign.center,
+              ),
             ),
           ),
           const SizedBox(

--- a/lib/ui/widgets/button_background.dart
+++ b/lib/ui/widgets/button_background.dart
@@ -16,11 +16,13 @@ import 'package:flutter/material.dart';
 class ButtonBackground extends StatelessWidget {
   final Color color;
   final Widget child;
+  final double border;
 
   const ButtonBackground({
     Key key,
     this.color,
     this.child,
+    this.border = 16.0,
   }) : super(key: key);
 
   @override
@@ -32,7 +34,7 @@ class ButtonBackground extends StatelessWidget {
         ),
         color: color,
       ),
-      padding: EdgeInsets.all(16.0),
+      padding: EdgeInsets.all(border),
       child: child,
     );
   }


### PR DESCRIPTION
closes #162 

**Description**
* Puts border as optional parameter of background
* Removes padding from statistics stats

<img width="424" alt="imagem" src="https://user-images.githubusercontent.com/10728633/77437888-17a34f00-6ddd-11ea-94d9-a363eca35b54.png">



