### PR TITLE
FIX - Status bar on iOS is always light (#177)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>io.flutter.embedded_views_preview</key>
 	<true/>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
Sets UIViewControllerBasedStatusBarAppearance properly to false in order to force app to always have a dark system status bar on iOS, regardless of the platform theme.

Closes #178 