### PR TITLE
FIX - Phone callback not working (#198)

### DIFF
--- a/lib/ui/screens/contacts/contacts_page.dart
+++ b/lib/ui/screens/contacts/contacts_page.dart
@@ -103,7 +103,7 @@ class _ContactsPageState extends State<ContactsPage> {
   _onContactTap(ContactModel contact) {
     switch (contact.contactType) {
       case ContactType.phone:
-        _launch("tel: ${contact.title}");
+        _launch("tel:${contact.title.replaceAll(RegExp(r'[^0-9+]'), '')}");
         break;
       case ContactType.link:
         var urlToOpen = contact.title;


### PR DESCRIPTION
Adds regex to properly format the phone number before launching for call.

Closes #198.