### PR TITLE
License Page Title Local override

### DIFF
--- a/lib/generated/intl/messages_all.dart
+++ b/lib/generated/intl/messages_all.dart
@@ -34,9 +34,8 @@ MessageLookupByLibrary _findExact(String localeName) {
 /// User programs should call this before using [localeName] for messages.
 Future<bool> initializeMessages(String localeName) async {
   var availableLocale = Intl.verifiedLocale(
-    localeName,
-    (locale) => _deferredLibraries[locale] != null,
-    onFailure: (_) => null);
+      localeName, (locale) => _deferredLibraries[locale] != null,
+      onFailure: (_) => null);
   if (availableLocale == null) {
     return new Future.value(false);
   }
@@ -56,8 +55,8 @@ bool _messagesExistFor(String locale) {
 }
 
 MessageLookupByLibrary _findGeneratedMessagesFor(String locale) {
-  var actualLocale = Intl.verifiedLocale(locale, _messagesExistFor,
-      onFailure: (_) => null);
+  var actualLocale =
+      Intl.verifiedLocale(locale, _messagesExistFor, onFailure: (_) => null);
   if (actualLocale == null) return null;
   return _findExact(actualLocale);
 }

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -20,63 +20,117 @@ class MessageLookup extends MessageLookupByLibrary {
   String get localeName => 'en';
 
   final messages = _notInlinedMessages(_notInlinedMessages);
-  static _notInlinedMessages(_) => <String, Function> {
-    "buttonTryAgain" : MessageLookupByLibrary.simpleMessage("Tentar novamente"),
-    "cannotConnectInternetDescription" : MessageLookupByLibrary.simpleMessage("Não conseguimos aceder à Internet para obter os dados mais recentes. Verifica a tua conexão."),
-    "checkDetails" : MessageLookupByLibrary.simpleMessage("Ver detalhes"),
-    "contactsPageMNEEmail" : MessageLookupByLibrary.simpleMessage("covid19@mne.pt"),
-    "contactsPageMNEEmailText" : MessageLookupByLibrary.simpleMessage("Canal do Ministério dos Negócios Estrangeiros de emergência aos portugueses em viagem."),
-    "contactsPageMNENumber" : MessageLookupByLibrary.simpleMessage("+351 217 929 755"),
-    "contactsPageMNENumberText" : MessageLookupByLibrary.simpleMessage("Linha do Ministério dos Negócios Estrangeiros de emergência aos portugueses em viagem."),
-    "contactsPageMSWeb" : MessageLookupByLibrary.simpleMessage("covid19.min-saude.pt"),
-    "contactsPageMSWebText" : MessageLookupByLibrary.simpleMessage("Plataforma da DGS para esclarecimentos sobre a COVID-19."),
-    "contactsPageSNSEmail" : MessageLookupByLibrary.simpleMessage("atendimento@SNS24.gov.pt"),
-    "contactsPageSNSEmailText" : MessageLookupByLibrary.simpleMessage("Canal SNS 24 para esclarecimentos de dúvidas. Não utilizar para diagnóstico médico."),
-    "contactsPageSNSNumber" : MessageLookupByLibrary.simpleMessage("808 24 24 24"),
-    "contactsPageSNSNumberText" : MessageLookupByLibrary.simpleMessage("Linha SNS 24 para esclarecimentos de diagnóstico médico."),
-    "contactsPageSSNumber" : MessageLookupByLibrary.simpleMessage("300 502 502"),
-    "contactsPageSSNumberText" : MessageLookupByLibrary.simpleMessage("Linha Segurança Social para esclarecimentos sobre assistência a familiares, baixas e quarentena."),
-    "contactsPageTitle" : MessageLookupByLibrary.simpleMessage("Contactos úteis"),
-    "defaultError" : MessageLookupByLibrary.simpleMessage("An error has occurred"),
-    "faqPageResponsableEntity" : MessageLookupByLibrary.simpleMessage("Entidade Responsável"),
-    "faqPageTitle" : MessageLookupByLibrary.simpleMessage("Perguntas Frequentes"),
-    "homePageConfirmedCases" : MessageLookupByLibrary.simpleMessage("Casos confirmados de COVID-19 em Portugal"),
-    "homePageTitle" : MessageLookupByLibrary.simpleMessage("Resposta de Portugal ao Covid-19"),
-    "initiativesPageTitle" : MessageLookupByLibrary.simpleMessage("Iniciativas"),
-    "lastUpdated" : MessageLookupByLibrary.simpleMessage("Última actualização: "),
-    "licencesPageTitle" : MessageLookupByLibrary.simpleMessage("Licenças Open-Source"),
-    "licensesPageTitle" : MessageLookupByLibrary.simpleMessage("Licenças Open-Source"),
-    "measuresHomepageButton" : MessageLookupByLibrary.simpleMessage("Medidas excecionais de resposta À COVID-19"),
-    "measuresPageMeasures" : MessageLookupByLibrary.simpleMessage("Medidas Excecionais"),
-    "noConnection" : MessageLookupByLibrary.simpleMessage("Sem conexão"),
-    "notificationsPageDescription" : MessageLookupByLibrary.simpleMessage("Que notificações vai receber?\nInformações importantes sobre atualização dos dados constantes nesta aplicação e avisos/alertas das entidades oficiais."),
-    "notificationsPageOpenSettings" : MessageLookupByLibrary.simpleMessage("Abrir definições"),
-    "notificationsPagePermissionsMissing" : MessageLookupByLibrary.simpleMessage("Por favor, conceda permissões de notificação."),
-    "notificationsPageReceiveMeasures" : MessageLookupByLibrary.simpleMessage("Medidas do Governo"),
-    "notificationsPageReceiveNotifcations" : MessageLookupByLibrary.simpleMessage("Notificações"),
-    "notificationsPageReceiveOther" : MessageLookupByLibrary.simpleMessage("Outras"),
-    "notificationsPageReceiveQuestions" : MessageLookupByLibrary.simpleMessage("Perguntas Frequentes"),
-    "notificationsPageReceiveStats" : MessageLookupByLibrary.simpleMessage("Estatísticas"),
-    "screenAboutBuilt" : MessageLookupByLibrary.simpleMessage("Esta app foi construída com o apoio da VOST PT e Flutter Portugal"),
-    "screenAboutButtonOpenSource" : MessageLookupByLibrary.simpleMessage("Licenças Open-Source"),
-    "screenAboutButtonReport" : MessageLookupByLibrary.simpleMessage("Reportar Problema"),
-    "screenAboutContent1" : MessageLookupByLibrary.simpleMessage("Esta App pretende ser um guia prático para apoiar cidadãos, famílias e empresas no combate aos efeitos causados pelo COVID-19. Aqui poderá encontrar toda a informação e conhecer os apoios a que tem direito."),
-    "screenAboutContent2" : MessageLookupByLibrary.simpleMessage("Consulte as boas práticas e as recomendações das autoridades de Saúde, conheça os melhores conselhos para trabalhar a partir de casa e saiba como recorrer aos serviços públicos sem ter de se deslocar."),
-    "screenAboutContent3" : MessageLookupByLibrary.simpleMessage("Poderá ainda ficar a conhecer as medidas excecionais adotadas pelo Governo em cada área governativa e acompanhar as evoluções do estado epidemiológico do País. Está também disponível para consulta a legislação especificamente aprovada, bem como as diferentes comunicações do Governo nesta matéria."),
-    "screenAboutContent4" : MessageLookupByLibrary.simpleMessage("Além destas informações, pode aceder à lista completa dos contactos de emergência criados pelos diversos serviços públicos para que, de forma simples e eficiente, encontre a resposta que procura."),
-    "screenAboutContent5" : MessageLookupByLibrary.simpleMessage("Juntos venceremos este vírus."),
-    "screenAboutFooter1" : MessageLookupByLibrary.simpleMessage("#COVID19PT - 2020 VOSTPT - Voluntários Digitais em Situações de Emergências para Portugal."),
-    "screenAboutFooter2" : MessageLookupByLibrary.simpleMessage("Este site e seus materiais encontram-se sob uma licença Creative Commons CC BY-NC-SA: Atribuição-Não Comercial-Compartilha Igual."),
-    "screenAboutHashtag" : MessageLookupByLibrary.simpleMessage("#EstamosOn"),
-    "screenAboutTitle" : MessageLookupByLibrary.simpleMessage("Sobre"),
-    "screenNotificationsTitle" : MessageLookupByLibrary.simpleMessage("Notificações"),
-    "screenRemoteWorkTitle" : MessageLookupByLibrary.simpleMessage("Teletrabalho"),
-    "screenVideosTitle" : MessageLookupByLibrary.simpleMessage("Vídeos"),
-    "statisticsPageAwaitingResults" : MessageLookupByLibrary.simpleMessage("Aguardar Resultados"),
-    "statisticsPageConfirmed" : MessageLookupByLibrary.simpleMessage("Confirmados"),
-    "statisticsPageDataLabel" : MessageLookupByLibrary.simpleMessage("Dados DGS via ESRI Portugal"),
-    "statisticsPageRecovered" : MessageLookupByLibrary.simpleMessage("Recuperados"),
-    "statisticsPageStatistics" : MessageLookupByLibrary.simpleMessage("Estatísticas"),
-    "statisticsPageSuspects" : MessageLookupByLibrary.simpleMessage("Suspeitos")
-  };
+  static _notInlinedMessages(_) => <String, Function>{
+        "buttonTryAgain":
+            MessageLookupByLibrary.simpleMessage("Tentar novamente"),
+        "cannotConnectInternetDescription": MessageLookupByLibrary.simpleMessage(
+            "Não conseguimos aceder à Internet para obter os dados mais recentes. Verifica a tua conexão."),
+        "checkDetails": MessageLookupByLibrary.simpleMessage("Ver detalhes"),
+        "contactsPageMNEEmail":
+            MessageLookupByLibrary.simpleMessage("covid19@mne.pt"),
+        "contactsPageMNEEmailText": MessageLookupByLibrary.simpleMessage(
+            "Canal do Ministério dos Negócios Estrangeiros de emergência aos portugueses em viagem."),
+        "contactsPageMNENumber":
+            MessageLookupByLibrary.simpleMessage("+351 217 929 755"),
+        "contactsPageMNENumberText": MessageLookupByLibrary.simpleMessage(
+            "Linha do Ministério dos Negócios Estrangeiros de emergência aos portugueses em viagem."),
+        "contactsPageMSWeb":
+            MessageLookupByLibrary.simpleMessage("covid19.min-saude.pt"),
+        "contactsPageMSWebText": MessageLookupByLibrary.simpleMessage(
+            "Plataforma da DGS para esclarecimentos sobre a COVID-19."),
+        "contactsPageSNSEmail":
+            MessageLookupByLibrary.simpleMessage("atendimento@SNS24.gov.pt"),
+        "contactsPageSNSEmailText": MessageLookupByLibrary.simpleMessage(
+            "Canal SNS 24 para esclarecimentos de dúvidas. Não utilizar para diagnóstico médico."),
+        "contactsPageSNSNumber":
+            MessageLookupByLibrary.simpleMessage("808 24 24 24"),
+        "contactsPageSNSNumberText": MessageLookupByLibrary.simpleMessage(
+            "Linha SNS 24 para esclarecimentos de diagnóstico médico."),
+        "contactsPageSSNumber":
+            MessageLookupByLibrary.simpleMessage("300 502 502"),
+        "contactsPageSSNumberText": MessageLookupByLibrary.simpleMessage(
+            "Linha Segurança Social para esclarecimentos sobre assistência a familiares, baixas e quarentena."),
+        "contactsPageTitle":
+            MessageLookupByLibrary.simpleMessage("Contactos úteis"),
+        "defaultError":
+            MessageLookupByLibrary.simpleMessage("An error has occurred"),
+        "faqPageResponsableEntity":
+            MessageLookupByLibrary.simpleMessage("Entidade Responsável"),
+        "faqPageTitle":
+            MessageLookupByLibrary.simpleMessage("Perguntas Frequentes"),
+        "homePageConfirmedCases": MessageLookupByLibrary.simpleMessage(
+            "Casos confirmados de COVID-19 em Portugal"),
+        "homePageTitle": MessageLookupByLibrary.simpleMessage(
+            "Resposta de Portugal ao Covid-19"),
+        "initiativesPageTitle":
+            MessageLookupByLibrary.simpleMessage("Iniciativas"),
+        "lastUpdated":
+            MessageLookupByLibrary.simpleMessage("Última actualização: "),
+        "licencesPageTitle":
+            MessageLookupByLibrary.simpleMessage("Licenças Open-Source"),
+        "licensesPageTitle":
+            MessageLookupByLibrary.simpleMessage("Licenças Open-Source"),
+        "measuresHomepageButton": MessageLookupByLibrary.simpleMessage(
+            "Medidas excecionais de resposta À COVID-19"),
+        "measuresPageMeasures":
+            MessageLookupByLibrary.simpleMessage("Medidas Excecionais"),
+        "noConnection": MessageLookupByLibrary.simpleMessage("Sem conexão"),
+        "notificationsPageDescription": MessageLookupByLibrary.simpleMessage(
+            "Que notificações vai receber?\nInformações importantes sobre atualização dos dados constantes nesta aplicação e avisos/alertas das entidades oficiais."),
+        "notificationsPageOpenSettings":
+            MessageLookupByLibrary.simpleMessage("Abrir definições"),
+        "notificationsPagePermissionsMissing":
+            MessageLookupByLibrary.simpleMessage(
+                "Por favor, conceda permissões de notificação."),
+        "notificationsPageReceiveMeasures":
+            MessageLookupByLibrary.simpleMessage("Medidas do Governo"),
+        "notificationsPageReceiveNotifcations":
+            MessageLookupByLibrary.simpleMessage("Notificações"),
+        "notificationsPageReceiveOther":
+            MessageLookupByLibrary.simpleMessage("Outras"),
+        "notificationsPageReceiveQuestions":
+            MessageLookupByLibrary.simpleMessage("Perguntas Frequentes"),
+        "notificationsPageReceiveStats":
+            MessageLookupByLibrary.simpleMessage("Estatísticas"),
+        "screenAboutBuilt": MessageLookupByLibrary.simpleMessage(
+            "Esta app foi construída com o apoio da VOST PT e Flutter Portugal"),
+        "screenAboutButtonOpenSource":
+            MessageLookupByLibrary.simpleMessage("Licenças Open-Source"),
+        "screenAboutButtonReport":
+            MessageLookupByLibrary.simpleMessage("Reportar Problema"),
+        "screenAboutContent1": MessageLookupByLibrary.simpleMessage(
+            "Esta App pretende ser um guia prático para apoiar cidadãos, famílias e empresas no combate aos efeitos causados pelo COVID-19. Aqui poderá encontrar toda a informação e conhecer os apoios a que tem direito."),
+        "screenAboutContent2": MessageLookupByLibrary.simpleMessage(
+            "Consulte as boas práticas e as recomendações das autoridades de Saúde, conheça os melhores conselhos para trabalhar a partir de casa e saiba como recorrer aos serviços públicos sem ter de se deslocar."),
+        "screenAboutContent3": MessageLookupByLibrary.simpleMessage(
+            "Poderá ainda ficar a conhecer as medidas excecionais adotadas pelo Governo em cada área governativa e acompanhar as evoluções do estado epidemiológico do País. Está também disponível para consulta a legislação especificamente aprovada, bem como as diferentes comunicações do Governo nesta matéria."),
+        "screenAboutContent4": MessageLookupByLibrary.simpleMessage(
+            "Além destas informações, pode aceder à lista completa dos contactos de emergência criados pelos diversos serviços públicos para que, de forma simples e eficiente, encontre a resposta que procura."),
+        "screenAboutContent5": MessageLookupByLibrary.simpleMessage(
+            "Juntos venceremos este vírus."),
+        "screenAboutFooter1": MessageLookupByLibrary.simpleMessage(
+            "#COVID19PT - 2020 VOSTPT - Voluntários Digitais em Situações de Emergências para Portugal."),
+        "screenAboutFooter2": MessageLookupByLibrary.simpleMessage(
+            "Este site e seus materiais encontram-se sob uma licença Creative Commons CC BY-NC-SA: Atribuição-Não Comercial-Compartilha Igual."),
+        "screenAboutHashtag":
+            MessageLookupByLibrary.simpleMessage("#EstamosOn"),
+        "screenAboutTitle": MessageLookupByLibrary.simpleMessage("Sobre"),
+        "screenNotificationsTitle":
+            MessageLookupByLibrary.simpleMessage("Notificações"),
+        "screenRemoteWorkTitle":
+            MessageLookupByLibrary.simpleMessage("Teletrabalho"),
+        "screenVideosTitle": MessageLookupByLibrary.simpleMessage("Vídeos"),
+        "statisticsPageAwaitingResults":
+            MessageLookupByLibrary.simpleMessage("Aguardar Resultados"),
+        "statisticsPageConfirmed":
+            MessageLookupByLibrary.simpleMessage("Confirmados"),
+        "statisticsPageDataLabel":
+            MessageLookupByLibrary.simpleMessage("Dados DGS via ESRI Portugal"),
+        "statisticsPageRecovered":
+            MessageLookupByLibrary.simpleMessage("Recuperados"),
+        "statisticsPageStatistics":
+            MessageLookupByLibrary.simpleMessage("Estatísticas"),
+        "statisticsPageSuspects":
+            MessageLookupByLibrary.simpleMessage("Suspeitos")
+      };
 }

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -10,18 +10,19 @@ import 'intl/messages_all.dart';
 
 class S {
   S(this.localeName);
-  
-  static const AppLocalizationDelegate delegate =
-    AppLocalizationDelegate();
+
+  static const AppLocalizationDelegate delegate = AppLocalizationDelegate();
 
   static Future<S> load(Locale locale) {
-    final String name = (locale.countryCode?.isEmpty ?? false) ? locale.languageCode : locale.toString();
+    final String name = (locale.countryCode?.isEmpty ?? false)
+        ? locale.languageCode
+        : locale.toString();
     final String localeName = Intl.canonicalizedLocale(name);
     return initializeMessages(localeName).then((_) {
       Intl.defaultLocale = localeName;
       return S(localeName);
     });
-  } 
+  }
 
   static S of(BuildContext context) {
     return Localizations.of<S>(context, S);

--- a/lib/resources/custom_localization.dart
+++ b/lib/resources/custom_localization.dart
@@ -1,0 +1,41 @@
+///     This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class LicensesPageTitleTextLocal extends DefaultMaterialLocalizations {
+  final BuildContext context;
+
+  LicensesPageTitleTextLocal(Locale locale, this.context) : super();
+
+  @override
+  String get licensesPageTitle => "Licenças Open-Source";
+}
+
+class LicensesPageTitleTextLocalDelegate
+    extends LocalizationsDelegate<MaterialLocalizations> {
+  final BuildContext context;
+
+  const LicensesPageTitleTextLocalDelegate(this.context);
+
+  @override
+  Future<LicensesPageTitleTextLocal> load(Locale locale) =>
+      SynchronousFuture(LicensesPageTitleTextLocal(locale, context));
+
+  @override
+  bool shouldReload(LicensesPageTitleTextLocalDelegate old) => false;
+
+  @override
+  bool isSupported(Locale locale) => true;
+}

--- a/lib/ui/app.dart
+++ b/lib/ui/app.dart
@@ -25,6 +25,7 @@ import 'package:covid19mobile/providers/slider_provider.dart';
 import 'package:covid19mobile/providers/stats_provider.dart';
 import 'package:covid19mobile/providers/videos_provider.dart';
 import 'package:covid19mobile/resources/constants.dart';
+import 'package:covid19mobile/resources/custom_localization.dart';
 import 'package:covid19mobile/resources/style/themes.dart';
 import 'package:covid19mobile/ui/screens/about/about_page.dart';
 import 'package:covid19mobile/ui/screens/contacts/contacts_page.dart';
@@ -113,6 +114,7 @@ class CovidApp extends StatelessWidget {
         title: 'Covid 19 App',
         localizationsDelegates: [
           S.delegate,
+          LicensesPageTitleTextLocalDelegate(context),
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,


### PR DESCRIPTION
A solution to override the Licenses Material Page title,

In this case, I'm overriding the DefaultMaterialLocalizations class, more specifically the property: licensesPageTitle

Adding this new Localization class to App delegates