### PR TITLE
UI Fixes for video card

### DIFF
--- a/lib/ui/assets/colors.dart
+++ b/lib/ui/assets/colors.dart
@@ -62,4 +62,10 @@ class Covid19Colors {
 
   /// For use in list separator
   static const Color lightGreyLight = Color(0xffeceef0);
+
+  /// For use in shadows
+  static const Color black65 = Color(0xA6000000);
+
+  /// For use in overalaus
+  static const Color black50 = Color(0x80000000);
 }

--- a/lib/ui/widgets/card_video.dart
+++ b/lib/ui/widgets/card_video.dart
@@ -1,4 +1,5 @@
 import 'package:covid19mobile/resources/style/text_styles.dart';
+import 'package:covid19mobile/ui/assets/colors.dart';
 import 'package:flutter/material.dart';
 
 ///     This program is free software: you can redistribute it and/or modify
@@ -46,9 +47,8 @@ class CardVideo extends StatelessWidget {
     return GestureDetector(
       onTap: onPressed,
       child: Container(
-        height: 144.0,
         margin: const EdgeInsets.all(5.0),
-        padding: const EdgeInsets.all(18.0),
+        height: 144.0,
         alignment: Alignment.center,
         decoration: decoration,
         child: Stack(
@@ -60,6 +60,12 @@ class CardVideo extends StatelessWidget {
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 color: Theme.of(context).primaryColor,
+              ),
+            ),
+            Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(4.0),
+                color: Covid19Colors.black50,
               ),
             ),
             ButtonTheme(
@@ -85,15 +91,19 @@ class CardVideo extends StatelessWidget {
             if (label != null)
               Align(
                 alignment: labelAlignment,
-                child: Text(
-                  label,
-                  style: TextStyles.subtitle(color: Colors.white)
-                      .copyWith(shadows: [
-                    const Shadow(
-                      offset: Offset(0.0, 1.0),
-                      blurRadius: 3.0,
-                    ),
-                  ]),
+                child: Container(
+                  padding: const EdgeInsets.all(12.0),
+                  child: Text(
+                    label,
+                    style: TextStyles.subtitle(color: Colors.white)
+                        .copyWith(shadows: [
+                      const Shadow(
+                        offset: Offset(0.0, 1.0),
+                        blurRadius: 4.0,
+                        color: Covid19Colors.black65,
+                      ),
+                    ]),
+                  ),
                 ),
               ),
           ],


### PR DESCRIPTION
closes #229 

**Description**
* Change text shadow: 4px blur; x: 0px; y: 1px; opacity: 65%
* Change black overlay to 50% opacity
* Make sure margins are 12dp on the sides.

![Simulator Screen Shot - iPhone 11 - 2020-04-25 at 11 43 57](https://user-images.githubusercontent.com/10728633/80277917-4a957700-86ea-11ea-9d02-2f92182a8369.png)

