### PR TITLE
Adds different entry points to dev and prod

### DIFF
--- a/lib/main_common.dart
+++ b/lib/main_common.dart
@@ -1,0 +1,70 @@
+///     This program is free software: you can redistribute it and/or modify
+///    it under the terms of the GNU General Public License as published by
+///    the Free Software Foundation, either version 3 of the License, or
+///    (at your option) any later version.
+///
+///    This program is distributed in the hope that it will be useful,
+///    but WITHOUT ANY WARRANTY; without even the implied warranty of
+///    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+///    GNU General Public License for more details.
+///
+///    You should have received a copy of the GNU General Public License
+///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'dart:async';
+import 'dart:io';
+import 'package:covid19mobile/services/messaging_service.dart';
+import 'package:covid19mobile/ui/app.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/material.dart';
+
+AppConfig appConfig;
+
+/// Common entrypoint for the COVID-19 App
+/// 
+/// This will initialize the app given an [AppConfig] configuration
+void mainCommon(AppConfig appConfig) async {
+  final WidgetsBinding binding = WidgetsFlutterBinding.ensureInitialized();
+
+  /// Override automaticSystemUiAdjustment auto UI color overlay adjustment
+  /// on Android
+  if (Platform.isAndroid) {
+    binding.renderView.automaticSystemUiAdjustment = false;
+  }
+
+  var enableInDevMode = true;
+
+  /// Set `enableInDevMode` to true to see reports while in debug mode
+  /// This is only to be used for confirming that reports are being
+  /// submitted as expected. It is not intended to be used for everyday
+  /// development.
+  Crashlytics.instance.enableInDevMode = enableInDevMode;
+
+  /// Pass all uncaught errors from the framework to Crashlytics.
+  FlutterError.onError = Crashlytics.instance.recordFlutterError;
+
+  /// Sets appConfig globally
+  appConfig = AppConfig.dev;
+
+  /// Init Firebase messaging service
+  await MessagingService.init();
+
+  runZoned<Future<void>>(() async {
+    /// Run main app
+    runApp(CovidApp());
+  }, onError: (e, s) {
+    /// Register and sends error
+    Crashlytics.instance.recordError(e, s);
+
+    /// for debug:
+    if (enableInDevMode) {
+      logger.e('[Error]: ${e.toString()}');
+      logger.e('[Stacktrace]: ${s.toString()}');
+    }
+  });
+}
+
+enum AppConfig {
+  dev,
+  prod,
+}

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -17,7 +17,7 @@ import 'package:covid19mobile/main_common.dart';
 /// 
 /// To run the dev configuration, please use the following command: 
 /// 
-/// `flutter run`
+/// `flutter run -t lib/main_dev.dart`
 void main() async {
-  mainCommon(AppConfig.prod);
+  mainCommon(AppConfig.dev);
 }

--- a/lib/model/post_type.dart
+++ b/lib/model/post_type.dart
@@ -11,7 +11,7 @@
 ///    You should have received a copy of the GNU General Public License
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'package:covid19mobile/main.dart';
+import 'package:covid19mobile/main_common.dart';
 
 /// Post types
 enum PostTypes {

--- a/lib/services/covid_status/status_api_service.dart
+++ b/lib/services/covid_status/status_api_service.dart
@@ -11,7 +11,7 @@
 ///    You should have received a copy of the GNU General Public License
 ///    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import 'package:covid19mobile/main.dart';
+import 'package:covid19mobile/main_common.dart';
 import 'package:covid19mobile/model/api_response_model.dart';
 import 'package:covid19mobile/services/covid_status/status_api.dart';
 import 'package:covid19mobile/services/request_type.dart';

--- a/lib/services/estamoson/api_service.dart
+++ b/lib/services/estamoson/api_service.dart
@@ -13,7 +13,7 @@
 
 import 'dart:async';
 
-import 'package:covid19mobile/main.dart';
+import 'package:covid19mobile/main_common.dart';
 import 'package:covid19mobile/model/api_response_model.dart';
 import 'package:covid19mobile/model/post_type.dart';
 import 'package:covid19mobile/services/estamoson/api.dart';


### PR DESCRIPTION
closes #254 

Adds different entrypoint for dev and prod

To run the dev endpoint we use:

`flutter run -t lib/main_dev.dart`

To run the prod endpoint we use:

`flutter run`

This warrants that the CI/CD continues to use the `main.dart` file to deploy for production