### PR TITLE
#297: Add color gradient to UCI percentage

### DIFF
--- a/lib/ui/screens/statistics/details/components/plot_components.dart
+++ b/lib/ui/screens/statistics/details/components/plot_components.dart
@@ -34,6 +34,43 @@ class Covid19LineTouchData extends LineTouchData {
         );
 }
 
+class Covid19PercentageLineTouchData extends LineTouchData {
+  Covid19PercentageLineTouchData()
+      : super(
+          touchTooltipData: LineTouchTooltipData(
+            tooltipBgColor: Colors.white,
+            getTooltipItems: _lineTooltipItem,
+            fitInsideVertically: true,
+            fitInsideHorizontally: true,
+          ),
+          touchCallback: (LineTouchResponse touchResponse) {},
+          handleBuiltInTouches: true,
+        );
+
+  static List<LineTooltipItem> _lineTooltipItem(List<LineBarSpot> touchedSpots) {
+    if (touchedSpots == null || touchedSpots.length < 2) {
+      return null;
+    }
+
+    final int day = touchedSpots[0].x.truncate();
+    final String dayText = Covid19PlotBottomSideTitles.parseDateToReadable(day);
+    final TextStyle dayStyle = TextStyle(
+      color: Colors.black,
+      fontSize: 14,
+    );
+
+    final String percentageText = "${touchedSpots[1].y}%";
+    final TextStyle percentageStyle = dayStyle.copyWith(
+      fontWeight: FontWeight.bold
+    );
+
+    return [
+      LineTooltipItem(dayText, dayStyle),
+      LineTooltipItem(percentageText, percentageStyle),
+    ];
+  }
+}
+
 class Covid19BarTouchData extends BarTouchData {
   Covid19BarTouchData()
       : super(

--- a/lib/ui/screens/statistics/details/hospitalized_page.dart
+++ b/lib/ui/screens/statistics/details/hospitalized_page.dart
@@ -306,7 +306,7 @@ class _FullHospitalizedUCIComparedState
               LineChartData(
                 maxY: 101, // 101 to show the 100% value
                 minY: 0,
-                lineTouchData: Covid19LineTouchData(),
+                lineTouchData: Covid19PercentageLineTouchData(),
                 borderData: FlBorderData(show: false),
                 gridData: FlGridData(
                   verticalInterval: filter.intervalValue(),
@@ -332,7 +332,7 @@ class _FullHospitalizedUCIComparedState
                   LineChartBarData(
                     isCurved: filter != StatisticsFilter.last7,
                     barWidth: 4,
-                    colors: [Covid19Colors.vostBlue],
+                    colors: [Colors.transparent],
                     spots: List.generate(
                       currentlyShowingSpots.length,
                       (x) => FlSpot(currentlyShowingSpots[x].x, 100),
@@ -340,14 +340,29 @@ class _FullHospitalizedUCIComparedState
                     dotData: FlDotData(
                       show: false,
                     ),
+                    belowBarData: BarAreaData(
+                      gradientFrom: Offset(1, 1),
+                      gradientTo: Offset(1, 0),
+                      gradientColorStops: [0, 0.95],
+                      show: true,
+                      colors: gradientColors
+                        .map(
+                          (color) => color.withOpacity(0.5),
+                        )
+                        .toList(),
+                    ),
                   ),
                   LineChartBarData(
                     isCurved: filter != StatisticsFilter.last7,
                     barWidth: 2,
-                    colors: [Covid19Colors.lightBlue],
+                    colors: [Covid19Colors.vostBlue],
                     spots: currentlyShowingSpots,
                     dotData: FlDotData(
                       show: false,
+                    ),
+                    belowBarData: BarAreaData(
+                      show: true,
+                      colors: [Covid19Colors.vostBlue.withOpacity(0.5)],
                     ),
                   )
                 ],
@@ -357,9 +372,9 @@ class _FullHospitalizedUCIComparedState
         ),
         PlotLabelGender(
           leftLabel: S.of(context).hospitalized,
-          leftColor: Covid19Colors.vostBlue,
+          leftColor: Covid19Colors.lightBlue,
           rightLabel: S.of(context).ucihospitalized,
-          rightColor: Covid19Colors.lightBlue,
+          rightColor: Covid19Colors.vostBlue,
         ),
       ],
     );


### PR DESCRIPTION
Addresses #297.

fl_chart library always places tooltip close to top value, in this case 100%. Hence tooltip cannot be placed close to uci line.

![Screenshot_1614472154](https://user-images.githubusercontent.com/1899304/109404297-a0672b00-795c-11eb-9990-53a44481f93e.png)
